### PR TITLE
fix: reduce to 1 commit when releasing

### DIFF
--- a/.github/workflows/bump_version_and_release.yml
+++ b/.github/workflows/bump_version_and_release.yml
@@ -41,11 +41,6 @@ jobs:
           cat custom_components/$GITHUB_REPO/manifest.json
           echo $tag_name > VERSION
 
-      - name: 🚀　Add and commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: Bump version ${{ steps.release_drafter.outputs.tag_name }}
-
       - name: 📝　Publish release
         uses: release-drafter/release-drafter@v6
         id: release_published
@@ -65,10 +60,10 @@ jobs:
           unreleased: false
           addSections: '{"documentation":{"prefix":"**Documentation:**","labels":["documentation"]}}'
 
-      - name: ✅　Commit release notes
+      - name: ✅　Commit release notes and bump version
         uses: EndBug/add-and-commit@v9
         with:
-          message: Commit release notes ${{ steps.release_drafter.outputs.tag_name }}
+          message: Commit release notes and bump version ${{ steps.release_drafter.outputs.tag_name }}
 
       - name: 📦 Create zip file
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to combine version bump and release notes into a single commit for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->